### PR TITLE
libwavesync: add multicast support with IGMP join messages.

### DIFF
--- a/libwavesync/cli.py
+++ b/libwavesync/cli.py
@@ -64,7 +64,8 @@ def start_tx(args, loop):
     packetizer.create_socket(args.ip_list,
                              args.ttl,
                              args.multicast_loop,
-                             args.broadcast)
+                             args.broadcast,
+                             args.source_address)
 
     connection = loop.create_unix_connection(lambda: sample_reader, args.tx)
 

--- a/libwavesync/cli_args.py
+++ b/libwavesync/cli_args.py
@@ -126,6 +126,12 @@ def args_common(opt):
                      help="multicast group or a unicast address, "
                           "may be given multiple times with --tx")
 
+    opt.add_argument("--source-address",
+                     dest="source_address",
+                     metavar="SRCADDRESS",
+                     action="store",
+                     help="source address for packets, needed for proper multicast routing")
+
     opt.add_argument("--debug",
                      action="store_true",
                      help="enable debugging code")


### PR DESCRIPTION
Hi!

This finishes multicast support for wavesync. Receiver and sender join multicast groups if source address argument is given.

Kind regars,

André