### PR TITLE
libwavesync: switch to time for timestamp

### DIFF
--- a/libwavesync/packetizer.py
+++ b/libwavesync/packetizer.py
@@ -60,7 +60,7 @@ class Packetizer:
     def _create_status_packet(self, chunk_no):
         "Format status packet"
         flags = Packetizer.HEADER_STATUS
-        now = datetime.utcnow().timestamp()
+        now = time()
         dgram = flags + struct.pack('dIHBBHH',
                                     now,
                                     chunk_no,

--- a/libwavesync/time_machine.py
+++ b/libwavesync/time_machine.py
@@ -4,7 +4,7 @@ Handle small, millisecond precision, timestamps.
 `timemark' marks a time in future - certain number of milliseconds ahead of
 the current time.
 """
-from datetime import datetime
+import time
 import struct
 
 # Max latency which can be recorded. Can be limited by cli.
@@ -53,4 +53,4 @@ def to_absolute_timestamp(relative_ts, mark):
 
 def now():
     "Current UTC timestamp"
-    return datetime.utcnow().timestamp()
+    return time.time()


### PR DESCRIPTION
Usage of DateTime library forced a lookup in filesystem everytime it has been called.
This lead to a fs crash on an embedded device. With the patch, it even runs on standard routers with single core MIPS CPUs.

Switch all to time(), this reduced cpu usage by 50%.